### PR TITLE
[doc] Extend README with v0.10.x and v1.x.x info

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,25 @@ The provider manages the installed [Charts](https://github.com/helm/charts) in y
 
 ## Requirements
 
--	[Terraform](https://www.terraform.io/downloads.html) v0.12.x
+-	[Terraform](https://www.terraform.io/downloads.html) v0.12.x or later
 -	[Go](https://golang.org/doc/install) v1.14.x (to build the provider plugin)
 -   [Helm](https://github.com/helm/helm/releases) v3.x.x to deploy your charts
+
+### Legacy provider versions
+
+Helm provider v0.10.x
+-	See latest `release-0.10.x` branch
+-	Terraform v0.11.x or later (at least including v0.14.x)
+-	[Helm v2.x.x](https://v2.helm.sh/)
+
+Helm provider v1.x.x
+-	See latest `release-1.x.x` branch
+-	Terraform v0.11.x or later (at least including v0.14.x)
+-	Helm v3.x.x
+
+How to upgrade from Helm v2.x.x to v3.x.x:
+-	https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+-	https://helm.sh/docs/topics/v2_v3_migration/
 
 ## Getting Started
 


### PR DESCRIPTION
Help admins to upgrade from legacy provider versions by specifying Terraform version compatibility

### Description

It was hard to find information about the compatibility of older provider versions vs. Terraform versions.
This makes it hard for admins to find out in which order the provider and Terraform must be upgraded.

Therefore, I tested various combinations using `terraform init` to help others with outdated Terraform and/or provider versions.
(I only tested Terraform >= v0.11.14, since I was assuming that nobody is using Terraform v0.10 any more.)

To make the information easily accessible, I chose to target the master branch, since this is what people will see when opening the repo.
In case that you don't like this, I could instead create similar PRs targeting `release-0.10.x` and `release-1.x.x`.



### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
   N/A - no functionality was added.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-helm/blob/master/CHANGELOG.md):

```release-note
NONE
```
### References
Related to https://github.com/hashicorp/terraform-provider-helm/issues/661

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->
